### PR TITLE
Make footer buttons clickable on Portfolio screen

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { FaHome, FaPaintBrush, FaLinkedin, FaTwitter } from 'react-icons/fa';
 import { GoMarkGithub } from 'react-icons/go';
 import styled from 'styled-components';
-import Button from './FooterButton';
+import FooterButton from './FooterButton';
 
 const FooterContainer = styled.div`
     padding-bottom: 0px;
@@ -26,13 +26,13 @@ const Footer = props => (
     <FooterContainer>
         <div className="divider" />
         <div className="firstRow">
-            <Button
+            <FooterButton
                 title="Home"
                 icon={<FaHome />}
                 handler={props.setHome}
                 content={props.content}
             />
-            <Button
+            <FooterButton
                 title="Portfolio"
                 icon={<FaPaintBrush />}
                 handler={props.setPortfolio}
@@ -41,17 +41,17 @@ const Footer = props => (
         </div>
         <div className="divider" />
         <div className="secondRow">
-            <Button
+            <FooterButton
                 title="Github"
                 icon={<GoMarkGithub />}
                 path="https://github.com/tctrautman"
             />
-            <Button
+            <FooterButton
                 title="LinkedIn"
                 icon={<FaLinkedin />}
                 path="https://www.linkedin.com/in/timtrautman/"
             />
-            <Button
+            <FooterButton
                 title="Twitter"
                 icon={<FaTwitter />}
                 path="https://twitter.com/TimTrautman"

--- a/src/components/FooterButton.js
+++ b/src/components/FooterButton.js
@@ -45,7 +45,7 @@ const IconContainer = styled.div`
     }
 `;
 
-const Button = props => {
+const FooterContentButton = props => {
     return (
         <IconContainer title={props.title} content={props.content}>
             <a onClick={props.handler} href={props.path}>
@@ -58,4 +58,4 @@ const Button = props => {
     );
 };
 
-export default Button;
+export default FooterContentButton;

--- a/src/components/Gif.js
+++ b/src/components/Gif.js
@@ -9,6 +9,7 @@ const GifContainer = styled.div`
     height: 100%;
     display: inline-block;
     vertical-align: middle;
+    height: 220px;
 
     img {
         display: inline-block;

--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import MiniButton from './MiniButton';
-import { FaSun, FaMoon } from 'react-icons/fa';
 
 const Container = styled.div`
     font-family: 'Roboto', sans-serif;

--- a/src/components/MiniButton.js
+++ b/src/components/MiniButton.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import getColorType from './Project';
 
 const MiniButtonContainer = styled.a`
     color: ${props => props.theme.color};

--- a/src/components/Project.js
+++ b/src/components/Project.js
@@ -3,8 +3,6 @@ import styled from 'styled-components';
 import Gif from './Gif';
 import ProjectTab from './ProjectTab';
 import ProjectButtons from './ProjectButtons';
-import { FaListAlt } from 'react-icons/fa';
-import MiniButton from './MiniButton';
 import Description from './Description';
 
 let getColorType = props => {
@@ -51,13 +49,13 @@ const ProjectContainer = styled.div`
     }
 `;
 
-const FlipContainer = styled.div`
+/*const FlipContainer = styled.div`
     a {
         margin-top: 14px;
         float: right;
         margin-right: 20px;
     }
-`;
+`;*/
 
 const Project = props => {
     let proj = props.project;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -117,7 +117,7 @@ class Home extends Component {
                         <Footer
                             setHome={this._setHome}
                             setPortfolio={this._setPortfolio}
-                            content={this.state.content}
+                            
                         />
                     </Container>
                 </React.Fragment>


### PR DESCRIPTION
This PR:

- Removes some old unused code that was giving off warnings in development mode
- Reduces the size of the `Gif` component, which was extending below enough to make some `FooterButton` components un-clickable